### PR TITLE
Added command to Edit > Text menu

### DIFF
--- a/menus/title-case.cson
+++ b/menus/title-case.cson
@@ -1,0 +1,15 @@
+'menu': [
+  {
+    'label': 'Edit'
+    'submenu': [
+      'label': 'Text'
+      'submenu': [
+        { 'type': 'separator' }
+        {
+          'label': 'Title Case'
+          'command': 'title-case:convert'
+        }
+      ]
+    ]
+  }
+]


### PR DESCRIPTION
I think it would be good to have a menu for this too. The logical place is under `Edit > Text` since that's where `Upper Case` and `Lower Case` are.
