### PR TITLE
Assume selection to be word under cursor if no text highlighted

### DIFF
--- a/lib/title-case.coffee
+++ b/lib/title-case.coffee
@@ -13,4 +13,7 @@ module.exports =
     buffer.transact ->
       for selection in selections
         cased = toTitleCase selection.getText()
+        if(cased.length == 0)
+          selection.selectWord()
+          cased = toTitleCase selection.getText()
         selection.insertText("#{cased}")


### PR DESCRIPTION
This update creates a default behavior for the case when the cursor is within or touching a word, but no explicit text selection was made. Expands empty selections to cover the word (if any) beneath the cursor before performing the Title Casing.